### PR TITLE
chore: bump Go to 1.26.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.1
+          go-version: 1.26.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.26.0"
           cache: false
 
       - name: Run SAST (golangci-lint)
@@ -42,13 +42,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.26.0"
           cache: false
 
       - name: Run SCA (govulncheck)
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.24.1
+          go-version-input: 1.26.0
           go-package: ./...
           output-format: sarif
           output-file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: "latest"
+          install-mode: "goinstall"
           only-new-issues: true
           args: --timeout=10m
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.26.0"
 
       - name: Install go-junit-report
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kamushadenes/cloud-verify
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.26.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0


### PR DESCRIPTION
## Summary
- Update `go.mod` from Go 1.24.0 to 1.26.0 (removes toolchain directive, absorbed by go directive)
- Update all CI workflows (test, security, release) from Go 1.24.1 to 1.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)